### PR TITLE
update wampy.d.ts to work with in-browser typescript

### DIFF
--- a/wampy/wampy.d.ts
+++ b/wampy/wampy.d.ts
@@ -3,103 +3,103 @@
 // Definitions by: Konstantin Burkalev <https://github.com/KSDaemon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module "wampy" {
-
-    interface WampyOptions {
-        autoReconnect?: boolean;
-        reconnectInterval?: number;
-        maxRetries?: number;
-        transportEncoding?: string;
-        realm?: string;
-        helloCustomDetails?: any;
-        onChallenge?: (auth_method: string, challenge_details: string) => string;
-        authid?: string;
-        onConnect?: () => void;
-        onClose?: () => void;
-        onError?: () => void;
-        onReconnect?: () => void;
-        onReconnectSuccess?: () => void;
-        ws?: any;
-        msgpackCoder?: any;
-    }
-
-    interface WampyOpStatus {
-        code: number;
-        description: string;
-        reqId?: number;
-    }
-
-    interface SuccessErrorCallbacksHash {
-        onSuccess?: (data: any) => void;
-        onError?: (err: string) => void;
-    }
-
-    interface SubscribeCallbacksHash extends SuccessErrorCallbacksHash {
-        onEvent: (data: any) => void;
-    }
-
-    interface RegisterCallbacksHash extends SuccessErrorCallbacksHash {
-        rpc: (data: any, options: any) => any[];
-    }
-
-    interface CallSuccessErrorCallbacksHash {
-        onSuccess: (data: any) => any;
-        onError?: (err: string) => void;
-    }
-
-    interface AdvancedOptions {
-        exclude?: number | number[];
-        eligible?: number | number[];
-        exclude_me?: boolean;
-        disclose_me?: boolean;
-    }
-
-    interface PublishAdvancedOptions extends AdvancedOptions {
-        exclude_authid?: string | string[];
-        exclude_authrole?: string | string[];
-        eligible_authid?: string | string[];
-        eligible_authrole?: string | string[];
-    }
-
-    interface CallAdvancedOptions {
-        disclose_me?: boolean;
-        receive_progress?: boolean;
-        timeout?: number;
-    }
-
-    interface CancelAdvancedOptions {
-        mode?: "skip" | "kill" | "killnowait";
-    }
-
-    interface Wampy {
-        options(opts?: WampyOptions): WampyOptions | Wampy;
-        getOpStatus(): WampyOpStatus;
-        getSessionId(): number;
-        connect(url?: string): Wampy;
-        disconnect(): Wampy;
-        abort(): Wampy;
-        subscribe(topicURI: string, callbacks: (((data: any) => void) | SubscribeCallbacksHash)): Wampy;
-        unsubscribe(topicURI: string, callbacks?: (((data: any) => void) | SubscribeCallbacksHash)): Wampy;
-        publish(topicURI: string,
-                payload?: any,
-                callbacks?: SuccessErrorCallbacksHash,
-                advancedOptions?: PublishAdvancedOptions): Wampy;
-        call(topicURI: string,
-             payload?: any,
-             callbacks?: (((data: any) => void) | CallSuccessErrorCallbacksHash),
-             advancedOptions?: CallAdvancedOptions): Wampy;
-        cancel(reqId: number,
-               callbacks?: ((() => void) | SuccessErrorCallbacksHash),
-               advancedOptions?: CancelAdvancedOptions): Wampy;
-        register(topicURI: string, callbacks: (((data: any, options: any) => any[]) | RegisterCallbacksHash)): Wampy;
-        unregister(topicURI: string, callbacks?: ((() => void) | SuccessErrorCallbacksHash)): Wampy;
-    }
-
-    interface WampyInstance {
-        new(url?: string, options?: WampyOptions): Wampy;
-    }
-
-    var wampy: WampyInstance;
-
-    export default wampy;
+interface WampyOptions {
+    autoReconnect?: boolean;
+    reconnectInterval?: number;
+    maxRetries?: number;
+    transportEncoding?: string;
+    realm?: string;
+    helloCustomDetails?: any;
+    onChallenge?: (auth_method: string, challenge_details: string) => string;
+    authid?: string;
+    onConnect?: () => void;
+    onClose?: () => void;
+    onError?: () => void;
+    onReconnect?: () => void;
+    onReconnectSuccess?: () => void;
+    ws?: any;
+    msgpackCoder?: any;
 }
+
+interface WampyOpStatus {
+    code: number;
+    description: string;
+    reqId?: number;
+}
+
+interface SuccessErrorCallbacksHash {
+    onSuccess?: (data: any) => void;
+    onError?: (err: string) => void;
+}
+
+interface SubscribeCallbacksHash extends SuccessErrorCallbacksHash {
+    onEvent: (data: any) => void;
+}
+
+interface RegisterCallbacksHash extends SuccessErrorCallbacksHash {
+    rpc: (data: any, options: any) => any[];
+}
+
+interface CallSuccessErrorCallbacksHash {
+    onSuccess: (data: any) => any;
+    onError?: (err: string) => void;
+}
+
+interface AdvancedOptions {
+    exclude?: number | number[];
+    eligible?: number | number[];
+    exclude_me?: boolean;
+    disclose_me?: boolean;
+}
+
+interface PublishAdvancedOptions extends AdvancedOptions {
+    exclude_authid?: string | string[];
+    exclude_authrole?: string | string[];
+    eligible_authid?: string | string[];
+    eligible_authrole?: string | string[];
+}
+
+interface CallAdvancedOptions {
+    disclose_me?: boolean;
+    receive_progress?: boolean;
+    timeout?: number;
+}
+
+interface CancelAdvancedOptions {
+    mode?: "skip" | "kill" | "killnowait";
+}
+
+interface Wampy {
+    new (url?: string, options?: WampyOptions): Wampy;
+    options(opts?: WampyOptions): WampyOptions | Wampy;
+    getOpStatus(): WampyOpStatus;
+    getSessionId(): number;
+    connect(url?: string): Wampy;
+    disconnect(): Wampy;
+    abort(): Wampy;
+    subscribe(topicURI: string, callbacks: (((data: any) => void) | SubscribeCallbacksHash)): Wampy;
+    unsubscribe(topicURI: string, callbacks?: (((data: any) => void) | SubscribeCallbacksHash)): Wampy;
+    publish(topicURI: string,
+            payload?: any,
+            callbacks?: SuccessErrorCallbacksHash,
+            advancedOptions?: PublishAdvancedOptions): Wampy;
+    call(topicURI: string,
+         payload?: any,
+         callbacks?: (((data: any) => void) | CallSuccessErrorCallbacksHash),
+         advancedOptions?: CallAdvancedOptions): Wampy;
+    cancel(reqId: number,
+           callbacks?: ((() => void) | SuccessErrorCallbacksHash),
+           advancedOptions?: CancelAdvancedOptions): Wampy;
+    register(topicURI: string, callbacks: (((data: any, options: any) => any[]) | RegisterCallbacksHash)): Wampy;
+    unregister(topicURI: string, callbacks?: ((() => void) | SuccessErrorCallbacksHash)): Wampy;
+}
+
+
+declare var wampy: Wampy;
+
+declare module 'wampy'
+{
+    export = wampy
+}
+
+

--- a/wampy/wampy.d.ts
+++ b/wampy/wampy.d.ts
@@ -3,7 +3,8 @@
 // Definitions by: Konstantin Burkalev <https://github.com/KSDaemon>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-interface WampyOptions {
+interface WampyOptions
+{
     autoReconnect?: boolean;
     reconnectInterval?: number;
     maxRetries?: number;
@@ -21,55 +22,65 @@ interface WampyOptions {
     msgpackCoder?: any;
 }
 
-interface WampyOpStatus {
+interface WampyOpStatus
+{
     code: number;
     description: string;
     reqId?: number;
 }
 
-interface SuccessErrorCallbacksHash {
+interface SuccessErrorCallbacksHash
+{
     onSuccess?: (data: any) => void;
-    onError?: (err: string) => void;
+    onError?: (err: string, details: any) => void;
 }
 
-interface SubscribeCallbacksHash extends SuccessErrorCallbacksHash {
-    onEvent: (data: any) => void;
+interface SubscribeCallbacksHash extends SuccessErrorCallbacksHash
+{
+    onEvent: (args: any[], kwargs: any) => void;
 }
 
-interface RegisterCallbacksHash extends SuccessErrorCallbacksHash {
+interface RegisterCallbacksHash extends SuccessErrorCallbacksHash
+{
     rpc: (data: any, options: any) => any[];
 }
 
-interface CallSuccessErrorCallbacksHash {
-    onSuccess: (data: any) => any;
-    onError?: (err: string) => void;
+interface CallSuccessErrorCallbacksHash
+{
+    onSuccess: (args: any[], kwargs: any) => any;
+    onError?: (err: string, details: any, args: any[], kwargs: any) => void;
 }
 
-interface AdvancedOptions {
+interface AdvancedOptions
+{
     exclude?: number | number[];
     eligible?: number | number[];
     exclude_me?: boolean;
     disclose_me?: boolean;
 }
 
-interface PublishAdvancedOptions extends AdvancedOptions {
+interface PublishAdvancedOptions extends AdvancedOptions
+{
     exclude_authid?: string | string[];
     exclude_authrole?: string | string[];
     eligible_authid?: string | string[];
     eligible_authrole?: string | string[];
 }
 
-interface CallAdvancedOptions {
+interface CallAdvancedOptions
+{
     disclose_me?: boolean;
     receive_progress?: boolean;
     timeout?: number;
 }
 
-interface CancelAdvancedOptions {
+interface CancelAdvancedOptions
+{
     mode?: "skip" | "kill" | "killnowait";
 }
 
-interface Wampy {
+interface Wampy
+{
     new (url?: string, options?: WampyOptions): Wampy;
     options(opts?: WampyOptions): WampyOptions | Wampy;
     getOpStatus(): WampyOpStatus;
@@ -77,15 +88,15 @@ interface Wampy {
     connect(url?: string): Wampy;
     disconnect(): Wampy;
     abort(): Wampy;
-    subscribe(topicURI: string, callbacks: (((data: any) => void) | SubscribeCallbacksHash)): Wampy;
-    unsubscribe(topicURI: string, callbacks?: (((data: any) => void) | SubscribeCallbacksHash)): Wampy;
+    subscribe(topicURI: string, callbacks: (((args: any[], kwargs: any) => void) | SubscribeCallbacksHash)): Wampy;
+    unsubscribe(topicURI: string, callbacks?: (((args: any[], kwargs: any) => void) | SubscribeCallbacksHash)): Wampy;
     publish(topicURI: string,
             payload?: any,
             callbacks?: SuccessErrorCallbacksHash,
             advancedOptions?: PublishAdvancedOptions): Wampy;
     call(topicURI: string,
          payload?: any,
-         callbacks?: (((data: any) => void) | CallSuccessErrorCallbacksHash),
+         callbacks?: (((args: any[], kwargs: any) => void) | CallSuccessErrorCallbacksHash),
          advancedOptions?: CallAdvancedOptions): Wampy;
     cancel(reqId: number,
            callbacks?: ((() => void) | SuccessErrorCallbacksHash),
@@ -94,12 +105,12 @@ interface Wampy {
     unregister(topicURI: string, callbacks?: ((() => void) | SuccessErrorCallbacksHash)): Wampy;
 }
 
-
 declare var wampy: Wampy;
 
 declare module 'wampy'
 {
     export = wampy
 }
+
 
 


### PR DESCRIPTION
I'm not sure if this change may affect node-js (should not) but it makes wampy to work perfectly in browser:

```bash
typings install dt~wampy
```
and then
```bash
import * as Wampy from 'wampy'
```

Also updated arguments in callbacks to support wampy v4.*